### PR TITLE
Grabbing absolute path to /etc/grub.conf for 1.5.1

### DIFF
--- a/tasks/section_01_level1.yml
+++ b/tasks/section_01_level1.yml
@@ -122,6 +122,7 @@
   - name: Get Absolute Path to grub.conf
     command: readlink -f /etc/grub.conf
     register: readlink
+    always_run: yes
 
   - name: 1.5.1 Set User/Group Owner on /etc/grub.conf (Scored)
     file: >


### PR DESCRIPTION
This feels a little hacky but does address #2 for me.
