### PR TITLE
Adding default value for enable_ip6tables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,16 @@ lock_inactive: no
 #   no: don't alter iptables whatsoever
 enable_iptables: no
 
+# Enable ip6tables (CIS 4.8)
+# You should check to see that your current ip6tables configuration in
+# /etc/sysconfig/ip6tables is configured properly so that you don't lose access
+# to your server when ip6tables is enabled.  If you're alreading using ip6tables,
+# then this setting won't affect you either way.
+# Options:
+#   yes: enable ip6tables and load the rules from /etc/sysconfig/ip6tables
+#   no: don't alter ip6tables whatsoever
+enable_ip6tables: no
+
 # Disable IPv6 (CIS 4.4.2)
 # It's recommended to configure IPv6 properly instead of disabling it entirely.
 # If your organization really doesn't use IPv6 at all, you could accept the


### PR DESCRIPTION
Fixing 4.8 in ansible check mode for #7.
